### PR TITLE
Add puppet-blacksmith to support module release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@
 /tmp/
 /vendor/
 /convert_report.txt
+/update_report.txt
 .DS_Store

--- a/.pdkignore
+++ b/.pdkignore
@@ -19,4 +19,5 @@
 /tmp/
 /vendor/
 /convert_report.txt
+/update_report.txt
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: ruby
 cache: bundler
 before_install:
   - bundle -v
-  - rm Gemfile.lock || true
+  - rm -f Gemfile.lock
   - gem update --system
   - gem update bundler
   - gem --version
@@ -26,6 +26,8 @@ matrix:
       env: CHECK="syntax lint"
     -
       env: CHECK=metadata_lint
+    -
+      env: CHECK=release_checks
     -
       env: CHECK=spec
     -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-## Release 0.1.0
-
-**Features**
+## Release 0.1.1
 
 **Bugfixes**
 
-**Known Issues**
+Add puppet-blacksmith to support module release process.
+
+## Release 0.1.0
+
+Initial release of bolt_shim. Works with Bolt 0.19.0.

--- a/Gemfile
+++ b/Gemfile
@@ -28,10 +28,12 @@ group :development do
   gem "fast_gettext",                                  require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
   gem "json_pure", '<= 2.0.1',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
+  gem "json", '= 2.0.4',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.4.3')
   gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-blacksmith", '~> 3.4',                   require: false, platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
@@ -39,73 +41,24 @@ puppet_type = gem_type(puppet_version)
 facter_version = ENV['FACTER_GEM_VERSION']
 hiera_version = ENV['HIERA_GEM_VERSION']
 
-def puppet_older_than?(version)
-  puppet_version = ENV['PUPPET_GEM_VERSION']
-  !puppet_version.nil? &&
-    Gem::Version.correct?(puppet_version) &&
-    Gem::Requirement.new("< #{version}").satisfied_by?(Gem::Version.new(puppet_version.dup))
-end
-
 gems = {}
 
 gems['puppet'] = location_for(puppet_version)
 
 # If facter or hiera versions have been specified via the environment
-# variables, use those versions. If not, and if the puppet version is < 3.5.0,
-# use known good versions of both for puppet < 3.5.0.
-if facter_version
-  gems['facter'] = location_for(facter_version)
-elsif puppet_type == :gem && puppet_older_than?('3.5.0')
-  gems['facter'] = ['>= 1.6.11', '<= 1.7.5', require: false]
-end
+# variables
 
-if hiera_version
-  gems['hiera'] = location_for(ENV['HIERA_GEM_VERSION'])
-elsif puppet_type == :gem && puppet_older_than?('3.5.0')
-  gems['hiera'] = ['>= 1.0.0', '<= 1.3.0', require: false]
-end
+gems['facter'] = location_for(facter_version) if facter_version
+gems['hiera'] = location_for(hiera_version) if hiera_version
 
-if Gem.win_platform? && (puppet_type != :gem || puppet_older_than?('3.5.0'))
-  # For Puppet gems < 3.5.0 (tested as far back as 3.0.0) on Windows
-  if puppet_type == :gem
-    gems['ffi'] =            ['1.9.0',                require: false]
-    gems['minitar'] =        ['0.5.4',                require: false]
-    gems['win32-eventlog'] = ['0.5.3',    '<= 0.6.5', require: false]
-    gems['win32-process'] =  ['0.6.5',    '<= 0.7.5', require: false]
-    gems['win32-security'] = ['~> 0.1.2', '<= 0.2.5', require: false]
-    gems['win32-service'] =  ['0.7.2',    '<= 0.8.8', require: false]
-  else
-    gems['ffi'] =            ['~> 1.9.0',             require: false]
-    gems['minitar'] =        ['~> 0.5.4',             require: false]
-    gems['win32-eventlog'] = ['~> 0.5',   '<= 0.6.5', require: false]
-    gems['win32-process'] =  ['~> 0.6',   '<= 0.7.5', require: false]
-    gems['win32-security'] = ['~> 0.1',   '<= 0.2.5', require: false]
-    gems['win32-service'] =  ['~> 0.7',   '<= 0.8.8', require: false]
-  end
-
-  gems['win32-dir'] = ['~> 0.3', '<= 0.4.9', require: false]
-
-  if RUBY_VERSION.start_with?('1.')
-    gems['win32console'] = ['1.3.2', require: false]
-    # sys-admin was removed in Puppet 3.7.0 and doesn't compile under Ruby 2.x
-    gems['sys-admin'] =    ['1.5.6', require: false]
-  end
-
-  # Puppet < 3.7.0 requires these.
-  # Puppet >= 3.5.0 gem includes these as requirements.
-  # The following versions are tested to work with 3.0.0 <= puppet < 3.7.0.
-  gems['win32-api'] =           ['1.4.8', require: false]
-  gems['win32-taskscheduler'] = ['0.2.2', require: false]
-  gems['windows-api'] =         ['0.4.3', require: false]
-  gems['windows-pr'] =          ['1.2.3', require: false]
-elsif Gem.win_platform?
+if Gem.win_platform? && puppet_version =~ %r{^(file:///|git://)}
   # If we're using a Puppet gem on Windows which handles its own win32-xxx gem
   # dependencies (>= 3.5.0), set the maximum versions (see PUP-6445).
   gems['win32-dir'] =      ['<= 0.4.9', require: false]
   gems['win32-eventlog'] = ['<= 0.6.5', require: false]
   gems['win32-process'] =  ['<= 0.7.5', require: false]
   gems['win32-security'] = ['<= 0.2.5', require: false]
-  gems['win32-service'] =  ['<= 0.8.8', require: false]
+  gems['win32-service'] =  ['0.8.8', require: false]
 end
 
 gems.each do |gem_name, gem_params|

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,5 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
+
+PuppetLint.configuration.send('relative')

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-bolt_shim",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Puppet, Inc.",
   "summary": "Bolt adapter for PE Orchestrator",
   "license": "Apache-2.0",
@@ -86,7 +86,7 @@
       "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ],
-  "pdk-version": "1.4.1",
+  "pdk-version": "1.5.0.pre (gc69497c)",
   "template-url": "file:///opt/puppetlabs/pdk/share/cache/pdk-templates.git",
-  "template-ref": "1.4.1-0-g52adbbb"
+  "template-ref": "remotes/origin/master-0-g6fa2fae"
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,4 +27,9 @@ end
 
 RSpec.configure do |c|
   c.default_facts = default_facts
+  c.before :each do
+    # set to strictest setting for testing
+    # by default Puppet runs at warning level
+    Puppet.settings[:strict] = :warning
+  end
 end


### PR DESCRIPTION
Our release jobs depend on puppet-blacksmith. Add it via `pdk convert` with a nightly release.

Also prepare for 0.1.1 release.