### PR TITLE
(BOLT-643) Specify input method as stdin

### DIFF
--- a/tasks/command.json
+++ b/tasks/command.json
@@ -1,3 +1,4 @@
 {
-  "description": "This task serves as a bridge between Bolt and Orchestrator and is not intended to be run directly"
+  "description": "This task serves as a bridge between Bolt and Orchestrator and is not intended to be run directly",
+  "input_method": "stdin"
 }

--- a/tasks/script.json
+++ b/tasks/script.json
@@ -1,3 +1,4 @@
 {
-  "description": "This task serves as a bridge between Bolt and Orchestrator and is not intended to be run directly"
+  "description": "This task serves as a bridge between Bolt and Orchestrator and is not intended to be run directly",
+  "input_method": "stdin"
 }

--- a/tasks/upload.json
+++ b/tasks/upload.json
@@ -1,3 +1,4 @@
 {
-  "description": "This task serves as a bridge between Bolt and Orchestrator and is not intended to be run directly"
+  "description": "This task serves as a bridge between Bolt and Orchestrator and is not intended to be run directly",
+  "input_method": "stdin"
 }


### PR DESCRIPTION
Previously, we were using the default input method of "both", which
passes input over stdin and in environment variables. Because these
tasks can take very large parameters (especially upload and script),
they may fail to execute if the size of their params exceeds the
maximum allowable size for an environment variable. Because they don't
actually _use_ the environment variables, we now explicitly specify that
they should not be provided.