### PR TITLE
(BOLT-191) Add mode for copying directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.0
+
+**Feature**
+
+Add support for uploading directories. Corresponds to Bolt 1.1.0.
+
 ## Release 0.1.1
 
 **Bugfixes**

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-bolt_shim",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "Puppet, Inc.",
   "summary": "Bolt adapter for PE Orchestrator",
   "license": "Apache-2.0",

--- a/tasks/upload.rb
+++ b/tasks/upload.rb
@@ -2,7 +2,22 @@
 # frozen_string_literal: true
 
 require 'base64'
+require 'fileutils'
 require 'json'
+
+def write_dir(path, content, mode)
+  require 'puppet'
+  require 'puppet/module_tool/tar'
+  Tempfile.open('upload.tar.gz') do |tgz|
+    tgz.chmod(0o600)
+    File.binwrite(tgz, Base64.decode64(content))
+
+    # Puppet's tar doesn't give us control over where a directory is unpacked, so we pack
+    # the files in the directory than unpack into a new one.
+    Dir.mkdir(path, mode)
+    Puppet::ModuleTool::Tar.instance.unpack(tgz, path, Etc.getlogin || Etc.getpwuid.name)
+  end
+end
 
 def write_file(path, content, mode)
   source = Base64.decode64(content)
@@ -10,11 +25,14 @@ def write_file(path, content, mode)
     f.chmod(mode)
     f.write(source)
   end
-  { success: true }
 end
 
 params = JSON.parse(STDIN.read)
 
-result = write_file(params['path'], params['content'], params['mode'])
+if params['directory']
+  write_dir(params['path'], params['content'], params['mode'])
+else
+  write_file(params['path'], params['content'], params['mode'])
+end
 
-puts result.to_json
+puts({ success: true }.to_json)


### PR DESCRIPTION
Adds support for deserialize tar-gzipped directories when the
`directory` property is true.