### PR TITLE
(BOLT-815) Mark task arguments that are file content as sensitive

### DIFF
--- a/tasks/command.json
+++ b/tasks/command.json
@@ -1,4 +1,10 @@
 {
   "description": "This task serves as a bridge between Bolt and Orchestrator and is not intended to be run directly",
-  "input_method": "stdin"
+  "input_method": "stdin",
+  "parameters": {
+    "command": {
+      "type": "String",
+      "description": "The command to be executed"
+    }
+  }
 }

--- a/tasks/script.json
+++ b/tasks/script.json
@@ -1,4 +1,15 @@
 {
   "description": "This task serves as a bridge between Bolt and Orchestrator and is not intended to be run directly",
-  "input_method": "stdin"
+  "input_method": "stdin",
+  "parameters": {
+    "content": {
+      "type": "String",
+      "description": "The script content to be executed",
+      "sensitive": true
+    },
+    "arguments": {
+      "type": "Array[String]",
+      "description": "Arguments to pass to the script"
+    }
+  }
 }

--- a/tasks/upload.json
+++ b/tasks/upload.json
@@ -1,4 +1,23 @@
 {
   "description": "This task serves as a bridge between Bolt and Orchestrator and is not intended to be run directly",
-  "input_method": "stdin"
+  "input_method": "stdin",
+  "parameters": {
+    "directory": {
+      "type": "Boolean",
+      "description": "Whether the file content is a directory in tgz format"
+    },
+    "path": {
+      "type": "String",
+      "description": "The path to upload the file to"
+    },
+    "content": {
+      "type": "String",
+      "description": "The file content to upload",
+      "sensitive": true
+    },
+    "mode": {
+      "type": "Integer",
+      "description": "The numeric file mode to apply"
+    }
+  }
 }


### PR DESCRIPTION
The script and upload tasks take the file content to run or upload as a
string parameter. Previously, this content would be included in log
files and stored in the orchestrator database. This adds metadata for
the shim tasks to describe all the parameters, and marks the file
content parameters as sensitive to avoid storing or exposing them, as
well as avoid overwhelming the user with excessive output at debug
level.