### PR TITLE
(BOLT-830) Handle running scripts on windows targets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,3 +105,7 @@ Style/IfUnlessModifier:
   Enabled: false
 Style/SymbolProc:
   Enabled: false
+Style/DoubleNegation:
+  Enabled: false
+Style/Documentation:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,32 +7,23 @@ before_install:
   - bundle -v
   - rm -f Gemfile.lock
   - gem update --system
-  - gem update bundler
   - gem --version
   - bundle -v
 script:
   - 'bundle exec rake $CHECK'
 bundler_args: --without system_tests
 rvm:
-  - 2.4.1
+  - 2.5.1
 env:
-  - PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
+  global:
+    - BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_GEM_VERSION="~> 6.0"
 matrix:
   fast_finish: true
   include:
     -
-      env: CHECK=rubocop
+      env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     -
-      env: CHECK="syntax lint"
-    -
-      env: CHECK=metadata_lint
-    -
-      env: CHECK=release_checks
-    -
-      env: CHECK=spec
-    -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
-      rvm: 2.1.9
+      env: CHECK=parallel_spec
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,15 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 def location_for(place_or_version, fake_version = nil)
-  if place_or_version =~ %r{\A(git[:@][^#]*)#(.*)}
-    [fake_version, { git: Regexp.last_match(1), branch: Regexp.last_match(2), require: false }].compact
-  elsif place_or_version =~ %r{\Afile:\/\/(.*)}
-    ['>= 0', { path: File.expand_path(Regexp.last_match(1)), require: false }]
+  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
+  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
+
+  if place_or_version && (git_url = place_or_version.match(git_url_regex))
+    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
+  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
+    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
   else
     [place_or_version, { require: false }]
-  end
-end
-
-def gem_type(place_or_version)
-  if place_or_version =~ %r{\Agit[:@]}
-    :git
-  elsif !place_or_version.nil? && place_or_version.start_with?('file:')
-    :file
-  else
-    :gem
   end
 end
 
@@ -28,16 +21,14 @@ group :development do
   gem "fast_gettext",                                  require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
   gem "json_pure", '<= 2.0.1',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
-  gem "json", '= 2.0.4',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.4.3')
+  gem "json", '<= 2.0.4',                              require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.4.4')
   gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-blacksmith", '~> 3.4',                   require: false, platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
-puppet_type = gem_type(puppet_version)
 facter_version = ENV['FACTER_GEM_VERSION']
 hiera_version = ENV['HIERA_GEM_VERSION']
 

--- a/tasks/script.json
+++ b/tasks/script.json
@@ -10,6 +10,10 @@
     "arguments": {
       "type": "Array[String]",
       "description": "Arguments to pass to the script"
+    },
+    "name": {
+      "type": "Optional[String]",
+      "description": "The name of the script file including extension"
     }
   }
 }

--- a/tasks/script.rb
+++ b/tasks/script.rb
@@ -5,25 +5,137 @@ require 'base64'
 require 'json'
 require 'open3'
 require 'tempfile'
+require 'pathname'
+require 'fileutils'
 
-def command(command, arguments = [])
-  stdout, stderr, p = Open3.capture3(command, *arguments)
+module WinHelpers
+  class << self
+    PS_ARGS = %w[
+      -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass
+    ].freeze
+
+    def windows?
+      !!File::ALT_SEPARATOR
+    end
+
+    def powershell_script?(extension)
+      extension.casecmp('.ps1').zero?
+    end
+
+    def run_script(arguments, script_path)
+      mapped_args = arguments.map { |a|
+        "$invokeArgs.ArgumentList += @'\n#{a}\n'@"
+      }.join("\n")
+      <<-PS
+    $invokeArgs = @{
+      ScriptBlock = (Get-Command "#{script_path}").ScriptBlock
+      ArgumentList = @()
+    }
+    #{mapped_args}
+
+    try
+    {
+      Invoke-Command @invokeArgs
+    }
+    catch
+    {
+      Write-Error $_.Exception
+      exit 1
+    }
+    PS
+    end
+
+    def process_from_extension(path)
+      case Pathname(path).extname.downcase
+      when '.rb'
+        [
+          'ruby.exe',
+          ['-S', "\"#{path}\""],
+        ]
+      when '.ps1'
+        [
+          'powershell.exe',
+          [*PS_ARGS, '-File', "\"#{path}\""],
+        ]
+      when '.pp'
+        [
+          'puppet.bat',
+          ['apply', "\"#{path}\""],
+        ]
+      else
+        # Run the script via cmd, letting Windows extension handling determine how
+        [
+          'cmd.exe',
+          ['/c', "\"#{path}\""],
+        ]
+      end
+    end
+
+    def escape_arguments(arguments)
+      arguments.map do |arg|
+        if arg =~ %r{ }
+          "\"#{arg}\""
+        else
+          arg
+        end
+      end
+    end
+  end
+end
+
+def in_tmpdir
+  dir = Dir.mktmpdir
+  yield dir
+ensure
+  FileUtils.remove_entry dir if dir
+end
+
+def with_tmpscript(content, script_name)
+  in_tmpdir do |dir|
+    dest = File.join(dir, script_name)
+    File.write(dest, Base64.decode64(content))
+    File.chmod(0o750, dest)
+    yield dest, dir
+  end
+end
+
+def error(msg)
+  { stdout: '',
+    stderr: msg,
+    exit_code: 1 }
+end
+
+def command(command, arguments = [], options = {})
+  stdout, stderr, p = Open3.capture3(*command, *arguments, chdir: options[:dir])
   { stdout: stdout,
     stderr: stderr,
     exit_code: p.exitstatus }
 end
 
-def script(content, arguments)
-  tf = Tempfile.new('bolt_script')
-  source = Base64.decode64(content)
-  tf.chmod(0o700)
-  tf.write(source)
-  tf.close
-  command(tf.path, arguments)
+def script(content, arguments, script_name)
+  if script_name.nil?
+    legacy_bolt = true
+    script_name = 'bolt_script'
+  end
+
+  with_tmpscript(content, script_name) do |file, dir|
+    if WinHelpers.windows?
+      return error('Error: Incompatible Bolt version. Update to puppet-bolt version => 1.11.0') if legacy_bolt
+      if WinHelpers.powershell_script?(file)
+        command(['powershell.exe'] + [WinHelpers.run_script(arguments, file)], nil, dir: dir)
+      else
+        path, args = *WinHelpers.process_from_extension(file)
+        args += WinHelpers.escape_arguments(arguments)
+        command(args.unshift(path).join(' '), nil, dir: dir)
+      end
+    else
+      command(file, arguments, dir: dir)
+    end
+  end
 end
 
 params = JSON.parse(STDIN.read)
 
-result = script(params['content'], params['arguments'])
+result = script(params['content'], params['arguments'], params['name'])
 
 puts result.to_json


### PR DESCRIPTION
Previously running a script on windows targets would not work over the PCP transport. This commit adds logic in the bolt_shim::script task to handle running scripts on windows targets. This logic requires that the script `extension` is sent along with the script `content` and `arguments`. In order to maintain backwards compatability this is optional metadata. An error will be raised if the `extension` metadata is not specified and the target OS is determined to be windows.