### PR TITLE
added CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # take ownership of parts of the code base that should be reviewed by another
 # team.
 
-*  @puppetlabs/bolt
+*  @puppetlabs/skeletor

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# This will cause the code owners of this repo to be assigned review of any
+# opened PRs against the branches containing this file.
+# See https://help.github.com/en/articles/about-code-owners for info on how to
+# take ownership of parts of the code base that should be reviewed by another
+# team.
+
+*  @puppetlabs/bolt


### PR DESCRIPTION
Noticed when reviewing the code for a support case the CODEOWNERS file was missing

set the owner to:

@puppetlabs/bolt