### PR TITLE
(maint) Update travis configuration to not install bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,11 @@
 ---
-sudo: false
-dist: trusty
+sudo: required
 language: ruby
 cache: bundler
 before_install:
-  - bundle -v
-  - rm -f Gemfile.lock
-  - gem update --system
-  - gem --version
-  - bundle -v
+  - bundle config set without 'system_tests'
 script:
   - 'bundle exec rake $CHECK'
-bundler_args: --without system_tests
 rvm:
   - 2.5.1
 env:
@@ -20,10 +14,8 @@ env:
 matrix:
   fast_finish: true
   include:
-    -
-      env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
-    -
-      env: CHECK=parallel_spec
+    - env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
+    - env: CHECK=parallel_spec
 branches:
   only:
     - master


### PR DESCRIPTION
This updates the `.travis.yml` file to not install the `bundler` gem or
update `rubygems`. Travis already installs the latest version of bundler
and `rubygems` when setting up the environment.

This also removes some deprecated items such as `sudo: false` and the
`--without` option for `bundler`.