### PR TITLE
(maint) Update max supported puppet version to 7.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -83,7 +83,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 6.0.0"
+      "version_requirement": ">= 4.7.0 < 7.0.0"
     }
   ],
   "pdk-version": "1.5.0.pre (gc69497c)",


### PR DESCRIPTION
Puppet 6 is supported by the bolt_shim module, and the metadata was
simply out of date. This updates the supported version to include all
6.y Puppet versions.