### PR TITLE
(maint) Release prep for 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.3.1
+
+**Bugfixes**
+
+Document support for Puppet 6
+
 ## Release 0.3.0
 
 **Feature**

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-bolt_shim",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Puppet, Inc.",
   "summary": "Bolt adapter for PE Orchestrator",
   "license": "Apache-2.0",


### PR DESCRIPTION
This preps for releasing 0.3.1 which documents support for Puppet 6.