### PR TITLE
(maint) Make 'puppetlabs' the module author

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "puppetlabs-bolt_shim",
-  "version": "0.3.1",
-  "author": "Puppet, Inc.",
+  "version": "0.3.2",
+  "author": "puppetlabs",
   "summary": "Bolt adapter for PE Orchestrator",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-bolt_shim",


### PR DESCRIPTION
Releasing the module failed as an update to ci-job-configs pulled in a
newer Puppet version, which uses an updated puppet-blacksmith and the
new puppet-modulebuilder in place of puppetlabs_spec_helper.
puppet-modulebuilder [builds the name of the
package](https://github.com/puppetlabs/puppet-modulebuilder/blob/master/lib/puppet/modulebuilder/builder.rb#L306)
using `#{fullname}-#{version}` while [blacksmith looks
for](https://github.com/voxpupuli/puppet-blacksmith/blob/master/lib/puppet_blacksmith/forge.rb#L41)
`#{author}-#{short-name}-#{version}`. This translates to modulebuilder
generating a package `puppetlabs-bolt_shim-0.3.0` while blacksmith looks
for `Puppet Inc.-bolt_shim-0.3.0`. By renaming the author to
`puppetlabs` the regexes will align and this should pass. This is also
more correct, as the module's full name should include the correct
author.