### PR TITLE
Add port to service-url

### DIFF
--- a/docs/connect_bolt_pe.md
+++ b/docs/connect_bolt_pe.md
@@ -123,7 +123,7 @@ config:
   transport: pcp
   pcp:
     cacert: "certs/cert.pem"
-    service-url: "https://master.example.com:8150"
+    service-url: "https://master.example.com:8143"
     token-file: "tokens/token"
 ```
 

--- a/docs/connect_bolt_pe.md
+++ b/docs/connect_bolt_pe.md
@@ -123,7 +123,7 @@ config:
   transport: pcp
   pcp:
     cacert: "certs/cert.pem"
-    service-url: "https://master.example.com"
+    service-url: "https://master.example.com:8150"
     token-file: "tokens/token"
 ```
 


### PR DESCRIPTION
Because we don't include the port, users might assume that they don't need to specify the port.