### PR TITLE
(PE-32046) use command exit code for command shim

### DIFF
--- a/tasks/command.rb
+++ b/tasks/command.rb
@@ -16,3 +16,4 @@ params = JSON.parse(STDIN.read)
 result = command(params['command'])
 
 puts result.to_json
+exit p.exitstatus


### PR DESCRIPTION
Prior to this commit, commands that failed would be reported as succeeding
because the command shim did not use the exit code from the command invocation.
This commit changes the shim to exit with the same exit code as the command run.