### PR TITLE
(BOLT-1575) Make tmpdir in current directory, not /tmp

### DIFF
--- a/tasks/script.rb
+++ b/tasks/script.rb
@@ -43,15 +43,8 @@ module WinHelpers
   end
 end
 
-def in_tmpdir
-  dir = Dir.mktmpdir
-  yield dir
-ensure
-  FileUtils.remove_entry dir if dir
-end
-
 def with_tmpscript(content, script_name)
-  in_tmpdir do |dir|
+  Dir.mktmpdir(nil, File.expand_path(__dir__)) do |dir|
     dest = File.join(dir, script_name)
     File.write(dest, Base64.decode64(content))
     File.chmod(0o750, dest)


### PR DESCRIPTION
This updates the shim to create a temporary directory relative to the
directory that PXP agent uploads the tasks to, instead of in the system
tempdir. Using the system tempdir is an issue when users have the
directory mounted with `noexec`, which is required for CIS2 compliance
(and is a somewhat common configuration). In Bolt you can typically
configure a different tmpdir for SSH and WinRM transports to use, but
PCP doesn't have such a configuration option. Rather than making the
tmpdir configurable, this updates the shim to make a tmpdir relative to
`__dir__` which is the current directory.